### PR TITLE
Specify drop chance of Basic Circuit Board

### DIFF
--- a/pages/Circuit-Boards.md
+++ b/pages/Circuit-Boards.md
@@ -2,7 +2,7 @@ Circuit Boards are [Technical Components](https://github.com/Slimefun/Slimefun4/
 
 ## Obtaining
 ### Basic Circuit Board
-The Basic Circuit Board can be obtained by manually killing an Iron Golem. Upon the death of the Iron Golem, it has a 75% chance of dropping one Basic Circuit Board.
+The Basic Circuit Board can be obtained by manually killing an Iron Golem. Upon the death of the Iron Golem, it has a chance of dropping one Basic Circuit Board. This chance is 75% by default, but it can be changed in the configuration files by a server operator.
 
 ### Advanced Circuit Board
 The Advanced Circuit Board can be obtained via crafting in an [Enhanced Crafting Table](https://github.com/Slimefun/Slimefun4/wiki/Enhanced-Crafting-Table).

--- a/pages/Circuit-Boards.md
+++ b/pages/Circuit-Boards.md
@@ -2,7 +2,7 @@ Circuit Boards are [Technical Components](https://github.com/Slimefun/Slimefun4/
 
 ## Obtaining
 ### Basic Circuit Board
-The Basic Circuit Board can be obtained by manually killing an Iron Golem, upon the death of the Iron Golem it will drop one Basic Circuit Board.
+The Basic Circuit Board can be obtained by manually killing an Iron Golem. Upon the death of the Iron Golem, it has a 75% chance of dropping one Basic Circuit Board.
 
 ### Advanced Circuit Board
 The Advanced Circuit Board can be obtained via crafting in an [Enhanced Crafting Table](https://github.com/Slimefun/Slimefun4/wiki/Enhanced-Crafting-Table).


### PR DESCRIPTION
This adds a mention of the 75% drop chance of the Basic Circuit Board upon killing an Iron Golem; see [BasicCircuitBoard.java line 19](https://github.com/Slimefun/Slimefun4/blob/4c47a9cb932fcddc7b286a2c0a17e17df527f325/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/misc/BasicCircuitBoard.java#L19).