### PR TITLE
Correct some wrong information

### DIFF
--- a/pages/Ancient-Pedestal.md
+++ b/pages/Ancient-Pedestal.md
@@ -1,4 +1,4 @@
-The Ancient Pedestal is a block in the [Magical Items](https://github.com/Slimefun/Slimefun4/wiki/Magical-Items) category. It is essential in building a working [Ancient Altar](https://github.com/Slimefun/Slimefun4/wiki/Ancient-Altar).
+The Ancient Pedestal is a block in the [Magical Gadgets](https://github.com/Slimefun/Slimefun4/wiki/Magical-Gadgets) category. It is essential in building a working [Ancient Altar](https://github.com/Slimefun/Slimefun4/wiki/Ancient-Altar).
 
 ## Obtaining
 The Ancient Pedestal can be crafted in a [Magic Workbench](https://github.com/Slimefun/Slimefun4/wiki/Magic-Workbench).

--- a/pages/Cobalt-Ingot.md
+++ b/pages/Cobalt-Ingot.md
@@ -14,8 +14,6 @@ Combining the following items in a [Smeltery](https://github.com/Slimefun/Slimef
 
 ## Usage
 
-### Items
-
 * [Magnet](https://github.com/Slimefun/Slimefun4/wiki/Magnet)
 * [Cobalt Pickaxe](https://github.com/Slimefun/Slimefun4/wiki/Cobalt-Pickaxe)
 * [Electromagnet](https://github.com/Slimefun/Slimefun4/wiki/Electromagnet)

--- a/pages/Cobalt-Ingot.md
+++ b/pages/Cobalt-Ingot.md
@@ -14,11 +14,6 @@ Combining the following items in a [Smeltery](https://github.com/Slimefun/Slimef
 
 ## Usage
 
-### In other alloys
-
-* [Aluminum Bronze Ingot](https://github.com/Slimefun/Slimefun4/wiki/Aluminum-Bronze-Ingot)
-* [Corinthian Bronze Ingot](https://github.com/Slimefun/Slimefun4/wiki/Corinthian-Bronze-Ingot)
-
 ### Items
 
 * [Magnet](https://github.com/Slimefun/Slimefun4/wiki/Magnet)

--- a/pages/Solder-Ingot.md
+++ b/pages/Solder-Ingot.md
@@ -22,5 +22,5 @@ Combining the following items in a [Smeltery](https://github.com/Slimefun/Slimef
 
 * [Solder Jetpack](https://github.com/Slimefun/Slimefun4/wiki/Jetpacks)
 * [Solder Multi Tool](https://github.com/Slimefun/Slimefun4/wiki/Multi-Tools)
-* [Billon Jet Boots](https://github.com/Slimefun/Slimefun4/wiki/Jet-Boots)
+* [Solder Jet Boots](https://github.com/Slimefun/Slimefun4/wiki/Jet-Boots)
 * [Portable Geo Scanner](https://github.com/Slimefun/Slimefun4/wiki/Portable-Geo-Scanner)


### PR DESCRIPTION
The cobalt ingot has no usage in other alloys, so removed.
Solder ingot has one incorrect usage info.
Ancient pedestal was moved to magical gadgets list (#149), but the category in the Ancient Pedestal page isn't updated