### PR TITLE
Add clarification

### DIFF
--- a/pages/Discord-Rules.md
+++ b/pages/Discord-Rules.md
@@ -120,6 +120,7 @@ Do **NOT** post follow-up suggestions, each suggestion should be independent of 
 ### #server-showcase
 This channel is for advertising your Minecraft Server.<br>
 Your server must be publicly accessible (no whitelist) and must have Slimefun installed.<br>
+Your post must have enough information to connect to the server without the reader having to resort to search engines (IP address or Website link, for example).
 The same Server must not be posted again within 14 days, otherwise, we will delete your post as a duplicate.<br>
 You are NOT allowed to post a link to your discord server.
 

--- a/pages/Discord-Rules.md
+++ b/pages/Discord-Rules.md
@@ -120,7 +120,7 @@ Do **NOT** post follow-up suggestions, each suggestion should be independent of 
 ### #server-showcase
 This channel is for advertising your Minecraft Server.<br>
 Your server must be publicly accessible (no whitelist) and must have Slimefun installed.<br>
-Your post must have enough information to connect to the server without the reader having to resort to search engines (IP address or Website link, for example).
+Your post must include an IP address/Domain Name of the server.
 The same Server must not be posted again within 14 days, otherwise, we will delete your post as a duplicate.<br>
 You are NOT allowed to post a link to your discord server.
 


### PR DESCRIPTION
Recently we have had two issues with servers being posted both without IP address or links to a servers website, leading to a post in which readers would not be connect/find the server without an intermediate step. This (slightly) goes against the common sense element of 'publicly accessible' though not in a way that is explicitly stated within the current rule set. 
This additional line ensures that posts would need to direct the readers (and ourselves for checking Whitelist/Slimefun etc. from other rules parts) to the server.

PR is draft as this wouldn't be as simple as accepting the PR is valid but also that the rule variation is acceptable.