### PR TITLE
Fix onItemUseRightClick method name calls

### DIFF
--- a/pages/Developer-Guide-(4a-Right-Clicks).md
+++ b/pages/Developer-Guide-(4a-Right-Clicks).md
@@ -283,7 +283,7 @@ public class FireCake extends SlimefunItem {
         BlockUseHandler blockUseHandler = this::onBlockRightClick;
         addItemHandler(blockUseHandler);
         
-        ItemUseHandler itemUseHandler = this::onItemRightClick;
+        ItemUseHandler itemUseHandler = this::onItemUseRightClick;
         addItemHandler(itemUseHandler);
     }
     

--- a/pages/Developer-Guide-(4b-Radioactive-and-WitherProof).md
+++ b/pages/Developer-Guide-(4b-Radioactive-and-WitherProof).md
@@ -23,7 +23,7 @@ public class FireCake extends SlimefunItem {
         BlockUseHandler blockUseHandler = this::onBlockRightClick;
         addItemHandler(blockUseHandler);
         
-        ItemUseHandler itemUseHandler = this::onItemRightClick;
+        ItemUseHandler itemUseHandler = this::onItemUseRightClick;
         addItemHandler(itemUseHandler);
     }
     
@@ -262,7 +262,7 @@ public class FireCake extends SlimefunItem implements Radioactive, WitherProof {
         BlockUseHandler blockUseHandler = this::onBlockRightClick;
         addItemHandler(blockUseHandler);
         
-        ItemUseHandler itemUseHandler = this::onItemRightClick;
+        ItemUseHandler itemUseHandler = this::onItemUseRightClick;
         addItemHandler(itemUseHandler);
     }
     


### PR DESCRIPTION
The method name is `onItemUseRightClick`, but code call `onItemRightClick`