### PR TITLE
Corrected a typo (Bacpack -> Backpack)

### DIFF
--- a/pages/Backpacks.md
+++ b/pages/Backpacks.md
@@ -11,7 +11,7 @@ These come in 6 tiers, each tier providing more inventory slots to store items i
 | Backpack         | 18              |
 | Large Bacpack    | 27              |
 | Woven Backpack   | 36              |
-| Gilded Bacpack   | 45              |
+| Gilded Backpack   | 45              |
 | Radiant Backpack | 54              |
 
 There is also the Restored backpack, which you can obtain by executing `/sf backpack`.  

--- a/pages/Backpacks.md
+++ b/pages/Backpacks.md
@@ -11,7 +11,7 @@ These come in 6 tiers, each tier providing more inventory slots to store items i
 | Backpack         | 18              |
 | Large Bacpack    | 27              |
 | Woven Backpack   | 36              |
-| Gilded Backpack   | 45              |
+| Gilded Backpack  | 45             |
 | Radiant Backpack | 54              |
 
 There is also the Restored backpack, which you can obtain by executing `/sf backpack`.  


### PR DESCRIPTION
That's quite literally it.

Gilded Backpack was spelled as Gilded Bacpack