### PR TITLE
Fix getRadioactivity typo in page Developer Guide 4b - Radioactive-and-WitherProof

### DIFF
--- a/pages/Developer-Guide-(4b-Radioactive-and-WitherProof).md
+++ b/pages/Developer-Guide-(4b-Radioactive-and-WitherProof).md
@@ -81,7 +81,7 @@ public class FireCake extends SlimefunItem implements Radioactive {
     }
     
     @Override
-    public Radioactivity getRadiation() {
+    public Radioactivity getRadioactivity() {
       // ?
     }
     
@@ -106,7 +106,7 @@ public class FireCake extends SlimefunItem implements Radioactive {
     }
     
     @Override
-    public Radioactivity getRadiation() {
+    public Radioactivity getRadioactivity() {
         return Radioactivity.HIGH;
     }
     
@@ -248,7 +248,7 @@ public class FireCake extends SlimefunItem implements Radioactive, WitherProof {
     }
     
     @Override
-    public Radioactivity getRadiation() {
+    public Radioactivity getRadioactivity() {
         return Radioactivity.HIGH;
     }
     


### PR DESCRIPTION
In the Radioactive interface, there is a method called getRadioactivity(). However, on this page, all the example code misspells it as getRadiation() instead.

Replaced getRadiation with getRadioactivity.